### PR TITLE
Fix for IPv6 and mesh processing

### DIFF
--- a/siteMapping.py
+++ b/siteMapping.py
@@ -210,6 +210,9 @@ def reload():
                 for s in o['sites']:
                     for h in s['hosts']:
                         types = []
+                        if 'measurement_archives' not in h.keys():
+                            print("No measurement archive defined for ", h)
+                            continue
                         for ma in h['measurement_archives']:
                             if ma['type'].count('owamp') > 0:
                                 types.append('owamp')
@@ -257,3 +260,5 @@ def isProductionThroughput(ip):
         return True
     return False
 
+if __name__ == '__main__':
+    reload()

--- a/siteMapping.py
+++ b/siteMapping.py
@@ -5,7 +5,7 @@ import socket
 import time
 import requests
 import xml.etree.ElementTree as ET
-import os
+import ipaddress
 
 # suppress InsecureRequestWarning: Unverified HTTPS request is being made.
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
@@ -131,7 +131,14 @@ def reload():
                 continue
             p.ip = [i[4][0] for i in ips]
             for ip in ips:
-                PerfSonars[ip[4][0]] = p
+                if ':' in ip[4][0]:
+                    try:
+                        PerfSonars[ipaddress.IPv6Address(ip[4][0]).exploded] = p
+                    except ipaddress.AddressValueError:
+                        print('Failed to parse IPv6 address:', ip)
+                        continue
+                else:
+                    PerfSonars[ip[4][0]] = p
             sites.append(s["rc_site"])
             p.prnt()
         print('Perfsonars reloaded.')
@@ -163,7 +170,14 @@ def reload():
             p.ip = [i[4][0] for i in ips]
             p.prnt()
             for ip in ips:
-                PerfSonars[ip[4][0]] = p
+                if ':' in ip[4][0]:
+                    try:
+                        PerfSonars[ipaddress.IPv6Address(ip[4][0]).exploded] = p
+                    except ipaddress.AddressValueError:
+                        print('Failed to parse IPv6 address:', ip)
+                        continue
+                else:
+                    PerfSonars[ip[4][0]] = p
         print('Done')
     except:
         print("Could not get perfSONARs from GOCDB/OIM ...")
@@ -226,6 +240,8 @@ def getPS(ip):
     if (time.time() - ot) > 86400:
         print(ot)
         reload()
+    if ':' in ip:
+        ip = ipaddress.IPv6Address(ip).exploded
     if ip in PerfSonars:
         return [PerfSonars[ip].sitename, PerfSonars[ip].VO]
 
@@ -240,3 +256,4 @@ def isProductionThroughput(ip):
     if ip in throughputHosts:
         return True
     return False
+

--- a/siteMapping.py
+++ b/siteMapping.py
@@ -259,6 +259,3 @@ def isProductionThroughput(ip):
     if ip in throughputHosts:
         return True
     return False
-
-if __name__ == '__main__':
-    reload()


### PR DESCRIPTION
IPv6 now using ipaddress.IPv6Address to get canonical form before comparing

Explicit check if MA is present was introduced as mesh processing choked on hosts w/o MA.